### PR TITLE
Update module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-	"name": "gridScale",
+	"name": "scaleGrid",
 	"title": "Grid Scale Menu",
 	"description": "This should add some buttons to modify grids to the canvas. Updated for 0.4.5",
 	"version": "0.0.10",


### PR DESCRIPTION
rename module to "scaleGrid" so it matches the repo name and works with the automatically created repo zip.

The alternative option is to point your module json `download` propertty to a prebuilt zip file that has the folder as `gridScale`