### PR TITLE
Ensure extracted folder is named a scaleGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To install a module, follow these instructions:
 
 1. Download the zip file
 2. Extract the included folder to `public/modules` in your Foundry Virtual Tabletop installation folder.
+3. Make sure the extracted folder is named "scaleGrid" and not "scaleGrid-master". Rename it if necesarry.
 3. Restart Foundry Virtual Tabletop. 
 
 ## How to Use the plugin


### PR DESCRIPTION
Seems a problem a bunch of people easily run into. I found the solution only after searching on Foundry's Discord. I propose a one line edit to the instructions to make the lives of everyone easier.