### PR TITLE
Use _onClickLeft instead of _onMouseDown for FoundryVTT 0.5.6+

### DIFF
--- a/gridScale.js
+++ b/gridScale.js
@@ -267,7 +267,7 @@ class ScaleGridLayer extends CanvasLayer {
     let t = canvas.stage;
     let f = t._events;
     //console.log(f);
-    t.off("mousedown", canvas._onMouseDown);
+    t.off("mousedown", canvas._onClickLeft);
   }
 
   /**
@@ -278,7 +278,7 @@ class ScaleGridLayer extends CanvasLayer {
     let t = canvas.stage;
     let f = t._events;
     //console.log(f);
-    t.on("mousedown", canvas._onMouseDown);
+    t.on("mousedown", canvas._onClickLeft);
   }
 
 


### PR DESCRIPTION
This small patch makes scaleGrid work normally again in FVTT 0.5.6+, though I'm unsure if this patch is fully correct. I've tested this to work properly on my own instance.