### PR TITLE
draw placeholder objects when canvas is ready

### DIFF
--- a/gridScale.js
+++ b/gridScale.js
@@ -1155,22 +1155,23 @@ caclByXnY(x,y) {
 
 
   /**
-   *
+   * Initialize the ScaleGridLayer. Attach the button to the controls, draw the square, and the draw text.
    */
-  newHookTest(){
+  initialize() {
     Hooks.on('getSceneControlButtons', controls => {
-      //console.log(controls);
       console.log("Grid Scale | Testing User role = " + game.user.data.role)
       if (game.user.data.role == 4) {
-      controls.push(sgLayer.newButtons);
-      //console.log(controls);
+        controls.push(sgLayer.newButtons);
+      }
+    });
+    // only draw objects when canvas is ready
+    Hooks.on('canvasReady', _canvas => {
       sgLayer.setDrawChild();
       sgLayer.drawSomeText();
-    };
-    });
+    })
   }
 
-}     //ends extendedCanvas class
+} // ends extendedCanvas class
 
 
 //// Last bit to render and set function definitos
@@ -1178,7 +1179,7 @@ caclByXnY(x,y) {
 let sgLayer = new ScaleGridLayer();
 
 sgLayer.setButtons();
-sgLayer.newHookTest();
+sgLayer.initialize();
 
 // Add a releaseAll function to the GridLayer class so it can pass through the Canvas.tearDown method -- to be fixed in a future Foundry release
 GridLayer.prototype.releaseAll = function() {};

--- a/module.json
+++ b/module.json
@@ -1,14 +1,14 @@
 {
 	"name": "scaleGrid",
 	"title": "Grid Scale Menu",
-	"description": "This should add some buttons to modify grids to the canvas. Updated for 0.6.0",
-	"version": "0.0.12",
+	"description": "This should add some buttons to modify grids to the canvas. Updated for 0.7.8",
+	"version": "0.0.13",
 	"author": "UberV",
 	"scripts": ["./gridScale.js"],
 	"styles": ["./gridScale.css"],
 	"packs": [],
 	"minimumCoreVersion": "0.4.4",
-	"compatibleCoreVersion": "0.6.0",
+	"compatibleCoreVersion": "0.7.8",
     "url": "https://github.com/UberV/scaleGrid/",
     "manifest": "https://raw.githubusercontent.com/UberV/scaleGrid/master/module.json",
     "download": "https://github.com/UberV/scaleGrid/archive/master.zip"


### PR DESCRIPTION
This change fixes #19 by ensuring the canvas is initialized before the placeholder shape and text are drawn. This resolves the console error about `controls` being undefined. 

I took the opportunity to publish the module for validation by reviewers before merging. Once it's reviewed and merged, I will delete my pre-release version:
https://raw.githubusercontent.com/xmclark/scaleGrid/dev-release/module.json